### PR TITLE
2sxc MVPs (unfinished), Fixed Dnn Agencies 

### DIFF
--- a/Portals/0/2sxc/Content/_Dnn-Elements-Demo-JRF.cshtml
+++ b/Portals/0/2sxc/Content/_Dnn-Elements-Demo-JRF.cshtml
@@ -1,0 +1,49 @@
+@using DotNetNuke.Web.Client.ClientResourceManagement
+
+@{
+  // Get the full Dnn-Elements on the page as a JS module
+  var include = new DnnJsInclude 
+  {
+    FilePath = "//unpkg.com/@dnncommunity/dnn-elements/dist/dnn/dnn.esm.js", 
+    ForceProvider = "DnnPageHeaderProvider",
+    Priority = 1001, // stay out of the way?
+    HtmlAttributesAsString = "type:module,async:async,defer:defer,crossorigin:anonymous",
+  };
+  var loader = (Context.CurrentHandler as Page).FindControl("ClientResourceIncludes");
+  if (loader != null)
+  {
+    loader.Controls.Add(include);
+  }  
+}
+
+<div id="wrapper-@CmsContext.Module.Id">
+
+  <h2>2sxc View using Dnn-Elements</h2>
+
+  <h3>1. Simple Button, as is</h3>
+  <dnn-button>Default (label)</dnn-button>
+
+  <h3>2. Use some of the Button's attributes</h3>
+  <dnn-button 
+    size="large"
+    type="secondary"
+    reversed="true"
+    title="This should get passed along untouched and appear like a tooltip on hover" 
+    onclick="alert('this is a dnn-elements button');"
+  >
+    Large Secondary and Reversed
+  </dnn-button>
+
+  <h3>3. Who doesn't love a Color Picker?</h3>
+  <dnn-color-picker color="EF3E42"></dnn-color-picker>
+
+  <hr style="margin-top:4rem;">
+  <p>That's all folks. This page goes with <a href="https://dnncommunity.org/blogs/Post/12141/" target="_blank">this Blog article.</a></p>
+
+</div>
+
+<style>
+  h3 {
+    margin-top: 1rem;
+  }
+</style>

--- a/Portals/0/2sxc/DNNAgencies/_Agency__Details--redux.cshtml
+++ b/Portals/0/2sxc/DNNAgencies/_Agency__Details--redux.cshtml
@@ -1,0 +1,128 @@
+@inherits Custom.Hybrid.Razor12
+@* This inherits statement gets you features like App, CmsContext, Data etc. - you can delete this comment *@
+@using ToSic.Sxc.Services; @* Make it easier to use https://r.2sxc.org/services *@
+
+@using ToSic.Razor.Blade;
+
+@* Note: theme is still Bootstrap (v4.6.2) 20230225 JRF *@
+
+@{
+  var pageSvc = GetService<IPageService>();
+  var renderSvc = GetService<IRenderService>();
+  var imageSvc = GetService<IImageService>();
+  var logoSettings = AsDynamic(new { Width = 600, ResizeMode = "Max", Quality = 75 });
+  var mergedSettings = AsDynamic(logoSettings, Settings.Images.Content); // Merged settings, first one has higher priority
+
+  int agencyId = 0;
+  int.TryParse(urlQSParam("agency-details"), out agencyId);
+  var agencies = AsList(App.Data["News"]);
+  var item = agencies 
+    .Where(a => a.EntityId == agencyId)
+    .FirstOrDefault()
+  ;
+
+  if (item == null) {
+    <p>Sorry, no agency found with an id of @agencyId.</p>
+    <a class="btn btn-primary" href="@Link.To()">Back</a>
+    return;
+  }
+
+  @* first add some meta *@
+  pageSvc.SetTitle(item.Title.ToString() + " | DNN Agency Details | "); // why does original page name still get appended?
+  pageSvc.SetDescription(Text.Crop(Tags.Strip(item.Teaser), 150) + " | ");
+  // pageSvc.SetKeywords( ... ); // future
+}
+
+@if (false && isAccuratyIP()) { // see @functions below
+<pre>Debug:
+agencies.Count(): @agencies.Count()
+item.GetType(): @item.GetType()
+agency-details/ = @agencyId
+</pre>
+}
+
+<div class="container-fluid my-5"
+  id="wrapper-agencyid-@item.EntityId" 
+  @Edit.TagToolbar(item))
+>
+  <div class="row">
+
+    <div class="col-md-7 order-2 order-md-1">
+      <h1>@item.Title</h1>
+      <p>
+      @foreach (var cat in  @item.Categories)
+      {
+        <a href="@Link.To(parameters: "category=" + cat.UrlKey)"
+          title="Return to the list of agencies filtered on @cat.Name."
+        >@cat.Name</a>
+      }
+      </p>
+
+      @if(item.ShowTeaserInDetail) 
+      {
+        <p class="lead app-news-detail-teaser">
+          @item.Teaser
+        </p>
+      }    
+      @if (Text.Has(item.Website)) {
+        <p class="mb-1">Website: <a href="@Html.Raw(item.Website)" target="_blank"> @Html.Raw(item.Website)</a> </p>
+      }
+      @if (Text.Has(item.Email)) {
+        <p class="mb-1">Email: @Html.Raw(item.Email) </p>
+      }
+      @if (Text.Has(item.Phone)) {
+        <p class="mb-1">Phone: @Html.Raw(item.Phone) </p>
+      }
+    </div>
+
+    @if(Text.Has(item.Image)) {
+    <div class="col-md-5 order-1 order-md-2 mt-1 mb-5">
+      @imageSvc.Picture(item.Image, mergedSettings, imgAlt: "logo for " + item.Title, imgClass: "ml-1") @* <img src="item.Image" alt="@item.Title" class="img-fluid" /> *@
+    </div>
+    }
+
+    <div class="col order-3">
+      <p>
+        @renderSvc.All(item, field: "BodyContentBlocks", merge: item.Body)
+        @* @Html.Raw(item.Body) *@
+        @* old: @ToSic.SexyContent.ContentBlocks.Render.All(item, field: "BodyContentBlocks", merge: item.Body) *@
+      </p>
+    </div>
+
+    <div class="col-12 order-4 my-5">
+      <a class="btn btn-primary" href="@Link.To()">
+        <i class="fa-solid fa-chevrons-left"></i> @* sigh, no FontAwesome (yet) *@
+        Back
+      </a>
+    </div>
+
+  </div>
+</div>
+
+
+@functions {
+  // safely fetch our URL Param
+  public string urlQSParam(string paramName = "demo") {
+    string param = Request.QueryString[paramName];
+    return Text.Has(param, false) ? param : "0";
+  }
+  // by IP, is the remote IP address a known Accuraty WAN IP?
+  public bool isAccuratyIP() {
+    var list = new List<string> {
+      "127.0.0.1",        // localhost
+      "140.141.191.145",  // 1800 Oak
+      "97.81.36.168",     // RRMA/Obtuse 202212 JRF
+      "24.238.80.108",    // 132CPPA 202209 JRF
+    };
+    return list.Contains(GetIpAddress());
+  }
+  // Get IP address of the visitor
+  public string GetIpAddress() {
+    string stringIpAddress = HttpContext.Current.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+    if (stringIpAddress == null) {
+      stringIpAddress = HttpContext.Current.Request.ServerVariables["REMOTE_ADDR"];
+    }
+    return stringIpAddress;
+  }
+}
+

--- a/Portals/0/2sxc/DNNAgencies/_Agency__Details.cshtml
+++ b/Portals/0/2sxc/DNNAgencies/_Agency__Details.cshtml
@@ -1,15 +1,25 @@
-@using System.Web.UI.HtmlControls
+@using System.Web.UI.HtmlControls;
 @using Connect.Koi;
+
+
+@using Microsoft.Extensions.DependencyInjection;
+@using DotNetNuke.Common.Extensions;
+@using ToSic.Sxc.Services; @* renderSvc (see below) *@
+@using ToSic.Razor.Blade;
 
 @{
     var item = AsDynamic(Data["Default"]).FirstOrDefault();
     var lib = CreateInstance("_library.cshtml");
     
     var newsPage = "";
-    var newsPageTab = @Dnn.Module.TabID;
+    var newsPageTab = @Dnn.Module.TabID; // future? CmsContext.Page.Id; 
 
     var pageHandler = HttpContext.Current.Handler as Page;
     var tp = (DotNetNuke.Framework.CDefault)pageHandler;    
+
+    //var ServiceProvider = HttpContext.Current.GetScope().ServiceProvider;
+    //var renderSvc = ServiceProvider.GetService<IRenderService>(); 
+    // https://docs.2sxc.org/abyss/releases/history/v13/sxc-static-render/index.html
 }
 @if (pageHandler != null && tp != null)
 {
@@ -105,7 +115,11 @@ else
             }
             
             <p class="app-news-detail-body">
-                @ToSic.SexyContent.ContentBlocks.Render.All(item, field: "BodyContentBlocks", merge: item.Body)
+              <code>[ Unable to display content, a fix is in the works - 20230224 JRF ]</code>
+              @* code from pre-v13 2sxc:
+              @ToSic.SexyContent.ContentBlocks.Render.All(item, field: "BodyContentBlocks", merge: item.Body) 
+              *@
+
             </p>
 
             <p class="app-news-detail-body app-news-detail-body-more">

--- a/Portals/0/2sxc/DNNAgencies/_Agency__List--basic.cshtml
+++ b/Portals/0/2sxc/DNNAgencies/_Agency__List--basic.cshtml
@@ -1,6 +1,8 @@
 @using Connect.Koi;
 @using Dynlist = System.Collections.Generic.IEnumerable<dynamic>;
 
+@using ToSic.Razor.Blade;
+
 @{
     var lib = CreateInstance("_library.cshtml"); 
 
@@ -20,6 +22,8 @@
 
     Random rndm = new Random();
     var newsToShowRandomized = newsToShow.OrderBy(n => rndm.Next());
+
+    string urlDetailsParam = "agency-details"; // isAccuratyIP() ? "agency-details" : "detail";
 }
 
 @if(!String.IsNullOrEmpty(Content.NewsPage)) 
@@ -28,6 +32,9 @@
     newsPageTab = int.Parse((AsEntity(Content).GetBestValue("NewsPage")).Split(':')[1]);
 }
 
+@if (false && isAccuratyIP()) {
+<pre>@GetIpAddress() - polymorph, use alternate agency details View 20230224 JRF</pre>
+}
 
 <div class="app-news app-news-list sc-element @((Permissions.UserMayEditContent) ? "app-edit" : "")" >
     @Edit.Toolbar(actions: "new, contentitems", contentType: "News", prefill: new { Date = DateTime.Now.Date, ShowFrom = DateTime.Now.Date, ShowTo =  (DateTime.Now.Date.AddYears(3)).Date } , settings: new { hover = "left", showCondition = true })
@@ -66,7 +73,11 @@
         <div @Koi.Class("all='sc-element' bs3='col col-xs-12 col-sm-12 col-md-12 col-lg-12' bs4,unk='col-12 col-md-12 col-lg-12 col-xl-12'")>
             @Edit.Toolbar(item)
             @{
-                string detailsLink = @lib.LinkToPage(newsPageTab, "mid", ((String.IsNullOrEmpty(Content.MainModuleId)) ? (Dnn.Module.ModuleID).ToString() : (Content.MainModuleId)), "detail", item.EntityId.ToString(), "title", item.UrlKey);
+              string detailsLink = @lib.LinkToPage(newsPageTab
+                , "mid", ((String.IsNullOrEmpty(Content.MainModuleId)) ? (Dnn.Module.ModuleID).ToString() : (Content.MainModuleId))
+                , urlDetailsParam, item.EntityId.ToString()
+                , "title", item.UrlKey
+              );
             }
             <div class="app-details-link" onclick="window.open('@detailsLink','_self');">
                 <div class="row">
@@ -145,3 +156,23 @@
 <script src="@App.Path/dist/script.js" data-enableoptimizations="true" ></script>
 
 
+@functions {
+  // by IP, is the remote IP address a known Accuraty WAN IP?
+  public bool isAccuratyIP() {
+    var list = new List<string> {
+      "127.0.0.1",        // localhost
+      "140.141.191.145",  // 1800 Oak
+      "97.81.36.168",     // RRMA/Obtuse 202212 JRF
+      "24.238.80.108",    // 132CPPA 202209 JRF
+    };
+    return list.Contains(GetIpAddress());
+  }
+  // Get IP address of the visitor
+  public string GetIpAddress() {
+    string stringIpAddress = HttpContext.Current.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+    if (stringIpAddress == null) {
+      stringIpAddress = HttpContext.Current.Request.ServerVariables["REMOTE_ADDR"];
+    }
+    return stringIpAddress;
+  }
+}

--- a/Portals/0/2sxc/LeadershipTeam/_leadership-team.cshtml
+++ b/Portals/0/2sxc/LeadershipTeam/_leadership-team.cshtml
@@ -1,0 +1,135 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/orgchart/2.1.3/css/jquery.orgchart.min.css">
+
+<style type="text/css">
+.orgchart { background: #fff; }
+.orgchart td.left, .orgchart td.right, .orgchart td.top { border-color: #aaa; }
+.orgchart td>.down { background-color: #aaa; }
+.orgchart.l2r { position: relative; }
+.orgchart.l2r .node, .orgchart.r2l .node {
+    width: 80px;
+    height: 180px;
+    display: flex;
+    flex-direction: column;
+    display: inline-flex;
+}
+.orgchart .node .title .symbol {
+    float: none;
+    margin-top: 4px;
+    margin-right: 2px;
+}
+.orgchart.l2r .node .title {
+    transform: rotate(-90deg) translate(-55px,-55px) rotateY(180deg);
+    transform-origin: bottom center;
+    width: 180px;
+}
+.orgchart .node .title {
+    text-align: center;
+    font-size: 15px;
+    font-weight: 700;
+    height: 30px;
+    line-height: 30px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    background-color: rgba(217,83,79,.8);
+    color: #fff;
+    border-radius: 4px 4px 0 0;
+}
+.orgchart.l2r .node .content {
+    transform: rotate(-90deg) translate(-55px,-55px) rotateY(180deg);
+    transform-origin: top center;
+    width: 180px;
+}
+.orgchart .node .content {
+    box-sizing: border-box;
+    width: 100%;
+    height: 26px;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 18px;
+    border: 1px solid rgba(217,83,79,.8);
+    border-radius: 0 0 4px 4p;
+    text-align: center;
+    background-color: #fff;
+    color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.orgchart .node:hover {
+    background-color: rgba(183, 183, 183, 0.5);
+    transition: .5s;
+    cursor: default;
+    z-index: 20;
+}
+.orgchart .community .title { background-color: #1CA3DC; }
+.orgchart .community .content { border-color: #1CA3DC; }
+.orgchart .awareness .title { background-color: #024B6C; }
+.orgchart .awareness .content { border-color: #024B6C; }
+.orgchart .development .title { background-color: #128438; }
+.orgchart .development .content { border-color: #128438; }
+.orgchart .strategy .title { background-color: #C9510D; }
+.orgchart .strategy .content { border-color: #C9510D; }
+.orgchart .technology .title { background-color: #8B2131; }
+.orgchart .technology .content { border-color: #8B2131; }
+</style>
+
+<h2 class="text-center mt-4">Leadership Team Organization Chart</h2>
+<div id="chart-container" class="text-center"></div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/orgchart/2.1.3/js/jquery.orgchart.min.js"></script>
+
+<script lang="javascript">
+'use strict';
+
+(function($){
+
+  $(function() {
+
+    var datascource = {
+      'name': 'DNN Community',
+      'title': 'Leadership Team',
+      'children': [
+        { 'name': 'Will Strohl', 'title': 'Awareness', 'className': 'awareness',
+          'children': [
+            { 'name': 'Tycho de Waard', 'title': 'Community Website', 'className': 'awareness' },
+            { 'name': 'Clint Patterson', 'title': 'Evangelism', 'className': 'awareness' }
+          ]
+        },
+        { 'name': 'Peter Donker', 'title': 'Development', 'className': 'development',
+          'children': [
+            { 'name': 'Kelly Ford', 'title': 'Documentation', 'className': 'development' },
+            { 'name': 'Daniel Valadas', 'title': 'Core Modules', 'className': 'development' }
+          ]
+        },
+        { 'name': 'David Poindexter', 'title': 'Strategy', 'className': 'strategy',
+          'children': [
+            { 'name': 'Valadas/Poindexter', 'title': 'Issue Management', 'className': 'strategy' },
+            { 'name': 'Poindexter/Sellers', 'title': 'Special Projects', 'className': 'strategy' }
+          ]
+        },
+        { 'name': 'Mitchel Sellers', 'title': 'Technology', 'className': 'technology',
+          'children': [
+            { 'name': 'Daniel Valadas', 'title': 'Build & Release', 'className': 'technology' },
+            { 'name': 'Mitchel Sellers', 'title': 'Security', 'className': 'technology' },
+            { 'name': 'Mariëtte Knap', 'title': 'Testing', 'className': 'technology' }
+          ]
+        }
+      ],
+      'className': 'community'
+    };
+
+    var oc = $('#chart-container').orgchart({
+      'data' : datascource,
+      'nodeTitle': 'title',
+      'nodeContent': 'name',
+      'direction': 'l2r',
+      'parentNodeSymbol': 'fa-star',
+      'toggleSiblingsResp': 'false',
+      'visibleLevel': '3'
+    });
+
+  });
+
+})(jQuery);
+</script>

--- a/Portals/0/2sxc/MVPs/_exports/Query.mvp-profiles.json
+++ b/Portals/0/2sxc/MVPs/_exports/Query.mvp-profiles.json
@@ -1,0 +1,269 @@
+{
+  "_": {
+    "V": 1
+  },
+  "Entity": {
+    "Id": 1717,
+    "Version": 100,
+    "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a",
+    "Type": {
+      "Name": "DataPipeline",
+      "Id": "DataPipeline"
+    },
+    "Attributes": {
+      "String": {
+        "Description": {
+          "*": "ALL MVP profiles"
+        },
+        "Name": {
+          "*": "mvp-profiles"
+        },
+        "StreamsOut": {
+          "*": "ListContent,Default,CurrentMVPs,HonoraryMVPs,LifetimeMVPs"
+        },
+        "StreamWiring": {
+          "*": "1d6248ba-890b-46b0-8a3e-ed0550f9fd53:Default>Out:CurrentMVPs\r\nb836c21c-5eec-4098-97f3-de1ebb4e892c:Default>Out:HonoraryMVPs\r\n191fc8f1-738d-4eda-830f-1278f3459337:Default>Out:LifetimeMVPs\r\n5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Default>1d6248ba-890b-46b0-8a3e-ed0550f9fd53:Default\r\n5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Default>b836c21c-5eec-4098-97f3-de1ebb4e892c:Default\r\n5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Default>191fc8f1-738d-4eda-830f-1278f3459337:Default\r\nc8137bd3-bb0b-4de9-9c14-151e5ce974d5:Default>5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Default\r\nc8137bd3-bb0b-4de9-9c14-151e5ce974d5:Drafts>5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Drafts\r\nc8137bd3-bb0b-4de9-9c14-151e5ce974d5:Published>5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65:Published"
+        },
+        "TestParameters": {
+          "*": "[Module:ModuleID]=540"
+        }
+      },
+      "Boolean": {
+        "AllowEdit": {
+          "*": true
+        }
+      }
+    },
+    "Owner": "dnn:userid=2",
+    "Metadata": [
+      {
+        "Id": 1718,
+        "Version": 100,
+        "Guid": "c8137bd3-bb0b-4de9-9c14-151e5ce974d5",
+        "Type": {
+          "Name": "DataPipelinePart",
+          "Id": "DataPipelinePart"
+        },
+        "Attributes": {
+          "String": {
+            "Description": {
+              "*": ""
+            },
+            "Name": {
+              "*": "ICache"
+            },
+            "PartAssemblyAndType": {
+              "*": "ToSic.Eav.DataSources.Caches.ICache, ToSic.Eav.DataSources"
+            },
+            "VisualDesignerData": {
+              "*": "{\r\n  \"Top\": 740,\r\n  \"Left\": 400\r\n}"
+            }
+          }
+        },
+        "Owner": "dnn:userid=2",
+        "For": {
+          "Target": "Entity",
+          "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a"
+        }
+      },
+      {
+        "Id": 1719,
+        "Version": 100,
+        "Guid": "5b0ea8f2-4e90-4c88-8f14-8f8a3ffebd65",
+        "Type": {
+          "Name": "DataPipelinePart",
+          "Id": "DataPipelinePart"
+        },
+        "Attributes": {
+          "String": {
+            "Description": {
+              "*": ""
+            },
+            "Name": {
+              "*": "PublishingFilter"
+            },
+            "PartAssemblyAndType": {
+              "*": "ToSic.Eav.DataSources.PublishingFilter, ToSic.Eav.DataSources"
+            },
+            "VisualDesignerData": {
+              "*": "{\r\n  \"Top\": 500,\r\n  \"Left\": 440\r\n}"
+            }
+          }
+        },
+        "Owner": "dnn:userid=2",
+        "For": {
+          "Target": "Entity",
+          "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a"
+        }
+      },
+      {
+        "Id": 1733,
+        "Version": 61,
+        "Guid": "1d6248ba-890b-46b0-8a3e-ed0550f9fd53",
+        "Type": {
+          "Name": "DataPipelinePart",
+          "Id": "DataPipelinePart"
+        },
+        "Attributes": {
+          "String": {
+            "Description": {
+              "*": ""
+            },
+            "Name": {
+              "*": "CurrentMVPs"
+            },
+            "PartAssemblyAndType": {
+              "*": "ToSic.SexyContent.Environment.Dnn7.DataSources.DnnSqlDataSource, ToSic.SexyContent"
+            },
+            "VisualDesignerData": {
+              "*": "{\r\n  \"Top\": 280,\r\n  \"Left\": 172\r\n}"
+            }
+          }
+        },
+        "Owner": "dnn:userid=2",
+        "For": {
+          "Target": "Entity",
+          "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a"
+        },
+        "Metadata": [
+          {
+            "Id": 1735,
+            "Version": 32,
+            "Guid": "f152adc3-be53-4c73-ada8-2fb007dba6c0",
+            "Type": {
+              "Name": "ToSic.SexyContent.DataSources.DnnSqlDataSource",
+              "Id": "|Config ToSic.SexyContent.DataSources.DnnSqlDataSource"
+            },
+            "Attributes": {
+              "String": {
+                "ContentType": {
+                  "*": "CurrentMVPs"
+                },
+                "SelectCommand": {
+                  "*": "SELECT\n\tu.DisplayName,\n\tu.FirstName, \n\tu.LastName, \n\tu.UserID As [UserID], \n\tur.RoleID, \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 27) As [Photo], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 31) As [Website], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 50) As [Twitter], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 52) As [LinkedIn], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 49) As [Facebook], \n\t(SELECT ISNULL(l.Text , up.PropertyValue) FROM UserProfile up LEFT JOIN dbo.Lists l ON l.EntryID = CASE WHEN ISNUMERIC(up.PropertyValue)=1 THEN up.PropertyValue ELSE -1 END WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 40) As [Country],\n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 51) As [GitHub], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 48) As [Stackoverflow]\n\nFROM \n\tUserRoles ur INNER JOIN\n\tUsers u ON ur.UserID = u.UserID\n\nWHERE (ur.RoleID = 32)\n\nORDER BY NEWID()"
+                }
+              }
+            },
+            "Owner": "dnn:userid=2",
+            "For": {
+              "Target": "Entity",
+              "Guid": "1d6248ba-890b-46b0-8a3e-ed0550f9fd53"
+            }
+          }
+        ]
+      },
+      {
+        "Id": 1736,
+        "Version": 42,
+        "Guid": "b836c21c-5eec-4098-97f3-de1ebb4e892c",
+        "Type": {
+          "Name": "DataPipelinePart",
+          "Id": "DataPipelinePart"
+        },
+        "Attributes": {
+          "String": {
+            "Description": {
+              "*": ""
+            },
+            "Name": {
+              "*": "HonoraryMVPs"
+            },
+            "PartAssemblyAndType": {
+              "*": "ToSic.SexyContent.Environment.Dnn7.DataSources.DnnSqlDataSource, ToSic.SexyContent"
+            },
+            "VisualDesignerData": {
+              "*": "{\r\n  \"Top\": 280,\r\n  \"Left\": 446\r\n}"
+            }
+          }
+        },
+        "Owner": "dnn:userid=2",
+        "For": {
+          "Target": "Entity",
+          "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a"
+        },
+        "Metadata": [
+          {
+            "Id": 1737,
+            "Version": 9,
+            "Guid": "c4872a75-855f-47ea-8aa0-58067734e790",
+            "Type": {
+              "Name": "ToSic.SexyContent.DataSources.DnnSqlDataSource",
+              "Id": "|Config ToSic.SexyContent.DataSources.DnnSqlDataSource"
+            },
+            "Attributes": {
+              "String": {
+                "ContentType": {
+                  "*": "HonoraryMVPs"
+                },
+                "SelectCommand": {
+                  "*": "SELECT\n\tu.DisplayName,\n\tu.FirstName, \n\tu.LastName, \n\tu.UserID As [UserID], \n\tur.RoleID, \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 27) As [Photo], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 31) As [Website], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 50) As [Twitter], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 52) As [LinkedIn], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 49) As [Facebook], \n\t(SELECT ISNULL(l.Text , up.PropertyValue) FROM UserProfile up LEFT JOIN dbo.Lists l ON l.EntryID = CASE WHEN ISNUMERIC(up.PropertyValue)=1 THEN up.PropertyValue ELSE -1 END WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 40) As [Country],\n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 51) As [GitHub], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 47) As [Stackoverflow]\n\nFROM \n\tUserRoles ur INNER JOIN\n\tUsers u ON ur.UserID = u.UserID\n\nWHERE (ur.RoleID = 33)\n\nORDER BY NEWID()"
+                }
+              }
+            },
+            "Owner": "dnn:userid=2",
+            "For": {
+              "Target": "Entity",
+              "Guid": "b836c21c-5eec-4098-97f3-de1ebb4e892c"
+            }
+          }
+        ]
+      },
+      {
+        "Id": 1738,
+        "Version": 36,
+        "Guid": "191fc8f1-738d-4eda-830f-1278f3459337",
+        "Type": {
+          "Name": "DataPipelinePart",
+          "Id": "DataPipelinePart"
+        },
+        "Attributes": {
+          "String": {
+            "Description": {
+              "*": ""
+            },
+            "Name": {
+              "*": "LifetimeMVPs"
+            },
+            "PartAssemblyAndType": {
+              "*": "ToSic.SexyContent.Environment.Dnn7.DataSources.DnnSqlDataSource, ToSic.SexyContent"
+            },
+            "VisualDesignerData": {
+              "*": "{\r\n  \"Top\": 280,\r\n  \"Left\": 720\r\n}"
+            }
+          }
+        },
+        "Owner": "dnn:userid=2",
+        "For": {
+          "Target": "Entity",
+          "Guid": "00322596-3e9c-458e-ae7b-f3d172e0101a"
+        },
+        "Metadata": [
+          {
+            "Id": 1739,
+            "Version": 9,
+            "Guid": "7ecca30e-7df9-40f5-9c04-3e6b3d35a86f",
+            "Type": {
+              "Name": "ToSic.SexyContent.DataSources.DnnSqlDataSource",
+              "Id": "|Config ToSic.SexyContent.DataSources.DnnSqlDataSource"
+            },
+            "Attributes": {
+              "String": {
+                "ContentType": {
+                  "*": "LifetimeMVPs"
+                },
+                "SelectCommand": {
+                  "*": "SELECT\n\tu.DisplayName,\n\tu.FirstName, \n\tu.LastName, \n\tu.UserID As [UserID], \n\tur.RoleID, \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 27) As [Photo], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 31) As [Website], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 50) As [Twitter], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 52) As [LinkedIn], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 49) As [Facebook], \n\t(SELECT ISNULL(l.Text , up.PropertyValue) FROM UserProfile up LEFT JOIN dbo.Lists l ON l.EntryID = CASE WHEN ISNUMERIC(up.PropertyValue)=1 THEN up.PropertyValue ELSE -1 END WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 40) As [Country],\n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 51) As [GitHub], \n\t(SELECT up.PropertyValue FROM UserProfile up WHERE u.UserID = up.UserID And up.PropertyDefinitionID = 47) As [Stackoverflow]\n\nFROM \n\tUserRoles ur INNER JOIN\n\tUsers u ON ur.UserID = u.UserID\n\nWHERE (ur.RoleID = 41)\n\nORDER BY NEWID()"
+                }
+              }
+            },
+            "Owner": "dnn:userid=2",
+            "For": {
+              "Target": "Entity",
+              "Guid": "191fc8f1-738d-4eda-830f-1278f3459337"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Portals/0/2sxc/MVPs/_exports/View.CurrentMVPs.json
+++ b/Portals/0/2sxc/MVPs/_exports/View.CurrentMVPs.json
@@ -1,0 +1,87 @@
+{
+  "_": {
+    "V": 1
+  },
+  "Entity": {
+    "Id": 1740,
+    "Version": 16,
+    "Guid": "9b1f3af3-5365-41c3-9d52-f58a2b64e33a",
+    "Type": {
+      "Name": "2SexyContent-Template",
+      "Id": "2SexyContent-Template"
+    },
+    "Attributes": {
+      "String": {
+        "ContentTypeStaticName": {
+          "*": ""
+        },
+        "ListContentTypeStaticName": {
+          "*": ""
+        },
+        "ListPresentationTypeStaticName": {
+          "*": ""
+        },
+        "Location": {
+          "*": "Portal File System"
+        },
+        "Name": {
+          "*": "CurrentMVPs"
+        },
+        "Path": {
+          "*": "_currentMVPs.cshtml"
+        },
+        "PresentationTypeStaticName": {
+          "*": ""
+        },
+        "StreamsToPublish": {
+          "*": ""
+        },
+        "Type": {
+          "*": "C# Razor"
+        },
+        "ViewNameInUrl": {
+          "*": ""
+        }
+      },
+      "Entity": {
+        "ContentDemoEntity": {
+          "*": []
+        },
+        "ListContentDemoEntity": {
+          "*": []
+        },
+        "ListPresentationDemoEntity": {
+          "*": []
+        },
+        "Pipeline": {
+          "*": [
+            "00322596-3e9c-458e-ae7b-f3d172e0101a"
+          ]
+        },
+        "PresentationDemoEntity": {
+          "*": []
+        }
+      },
+      "Boolean": {
+        "IsHidden": {
+          "*": false
+        },
+        "PublishData": {
+          "*": false
+        },
+        "UseForList": {
+          "*": true
+        }
+      }
+    },
+    "Owner": "dnn:userid=2",
+    "Assets": [
+      {
+        "Storage": "app",
+        "Name": "_currentMVPs.cshtml",
+        "Folder": "",
+        "File": "\r\n@Edit.Toolbar()\r\n<div class=\"container\">\r\n    <div class=\"row\">\r\n        @foreach(var mvp in AsDynamic(Data[\"CurrentMVPs\"])){\r\n            <div class=\"card border-0 col-md-3 mb-3\">\r\n                <div class=\"bg-light rounded-top\">\r\n                    <img class=\"card-img-top rounded-circle p-4\" src=\"/DnnImageHandler.ashx?mode=profilepic&userId=@mvp.UserID&h=200&w=200\" alt=\"Card image cap\">\r\n                </div>\r\n                <div class=\"card-body text-center bg-secondary rounded-bottom\">\r\n                    <h4 class=\"card-title h-20\">@mvp.FirstName @mvp.LastName</h4>\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Country.ToString()) ? \"<p class=\\\"card-text h-20\\\">&nbsp;</p>\" : \"<p class=\\\"card-text\\\">\" + @mvp.Country + \"</p>\" )\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Website.ToString()) ? \"<p class=\\\"card-text h-20\\\"></p>\" : \"<p class=\\\"card-text\\\"><a href=\\\"\" + @mvp.Website + \"\\\" class=\\\"btn btn-primary\\\" target=\\\"_default\\\">Website</a></p>\" )\r\n                    <div class=\"row h-20\">\r\n                        <div class=\"col-md-12 h3\">\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Twitter.ToString()) ? \"\" : \"<a href=\\\"//twitter.com/\" + @mvp.Twitter + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-twitter px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.LinkedIn.ToString()) ? \"\" : \"<a href=\\\"//www.linkedin.com/in/\" + @mvp.LinkedIn + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-linkedin px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Facebook.ToString()) ? \"\" : \"<a href=\\\"//www.facebook.com/\" + @mvp.Facebook + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-facebook px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.GitHub.ToString()) ? \"\" : \"<a href=\\\"//github.com/\" + @mvp.GitHub + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-github px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Stackoverflow.ToString()) ? \"\" : \"<a href=\\\"//stackoverflow.com/users/\" + @mvp.Stackoverflow + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-stack-overflow px-1\\\"></i></a>\" )\r\n                        </div>\r\n                    </div>\r\n                </div>\r\n            </div>\r\n        }\r\n    </div>\r\n</div>"
+      }
+    ]
+  }
+}

--- a/Portals/0/2sxc/MVPs/_exports/View.HonoraryMVPs.json
+++ b/Portals/0/2sxc/MVPs/_exports/View.HonoraryMVPs.json
@@ -1,0 +1,87 @@
+{
+  "_": {
+    "V": 1
+  },
+  "Entity": {
+    "Id": 1750,
+    "Version": 1,
+    "Guid": "adf20da0-eb8a-4c0b-b71c-b73cd73ecc89",
+    "Type": {
+      "Name": "2SexyContent-Template",
+      "Id": "2SexyContent-Template"
+    },
+    "Attributes": {
+      "String": {
+        "ContentTypeStaticName": {
+          "*": ""
+        },
+        "ListContentTypeStaticName": {
+          "*": ""
+        },
+        "ListPresentationTypeStaticName": {
+          "*": ""
+        },
+        "Location": {
+          "*": "Portal File System"
+        },
+        "Name": {
+          "*": "HonoraryMVPs"
+        },
+        "Path": {
+          "*": "_honoraryMVPs.cshtml"
+        },
+        "PresentationTypeStaticName": {
+          "*": ""
+        },
+        "StreamsToPublish": {
+          "*": ""
+        },
+        "Type": {
+          "*": "C# Razor"
+        },
+        "ViewNameInUrl": {
+          "*": ""
+        }
+      },
+      "Entity": {
+        "ContentDemoEntity": {
+          "*": []
+        },
+        "ListContentDemoEntity": {
+          "*": []
+        },
+        "ListPresentationDemoEntity": {
+          "*": []
+        },
+        "Pipeline": {
+          "*": [
+            "00322596-3e9c-458e-ae7b-f3d172e0101a"
+          ]
+        },
+        "PresentationDemoEntity": {
+          "*": []
+        }
+      },
+      "Boolean": {
+        "IsHidden": {
+          "*": false
+        },
+        "PublishData": {
+          "*": false
+        },
+        "UseForList": {
+          "*": false
+        }
+      }
+    },
+    "Owner": "dnn:userid=2",
+    "Assets": [
+      {
+        "Storage": "app",
+        "Name": "_honoraryMVPs.cshtml",
+        "Folder": "",
+        "File": "\r\n@Edit.Toolbar()\r\n<div class=\"container\">\r\n    <div class=\"row\">\r\n        @foreach(var mvp in AsDynamic(Data[\"HonoraryMVPs\"])){\r\n            <div class=\"card border-0 col-md-3 mb-3\">\r\n                <div class=\"bg-light rounded-top\">\r\n                    <img class=\"card-img-top rounded-circle p-4\" src=\"/DnnImageHandler.ashx?mode=profilepic&userId=@mvp.UserID&h=200&w=200\" alt=\"Card image cap\">\r\n                </div>\r\n                <div class=\"card-body text-center bg-secondary rounded-bottom\">\r\n                    <h4 class=\"card-title h-20\">@mvp.FirstName @mvp.LastName</h4>\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Country.ToString()) ? \"<p class=\\\"card-text h-20\\\">&nbsp;</p>\" : \"<p class=\\\"card-text\\\">\" + @mvp.Country + \"</p>\" )\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Website.ToString()) ? \"<p class=\\\"card-text h-20\\\"></p>\" : \"<p class=\\\"card-text\\\"><a href=\\\"\" + @mvp.Website + \"\\\" class=\\\"btn btn-primary\\\" target=\\\"_default\\\">Website</a></p>\" )\r\n                    <div class=\"row h-20\">\r\n                        <div class=\"col-md-12 h3\">\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Twitter.ToString()) ? \"\" : \"<a href=\\\"//twitter.com/\" + @mvp.Twitter + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-twitter px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.LinkedIn.ToString()) ? \"\" : \"<a href=\\\"//www.linkedin.com/in/\" + @mvp.LinkedIn + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-linkedin px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Facebook.ToString()) ? \"\" : \"<a href=\\\"//www.facebook.com/\" + @mvp.Facebook + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-facebook px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.GitHub.ToString()) ? \"\" : \"<a href=\\\"//github.com/\" + @mvp.GitHub + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-github px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Stackoverflow.ToString()) ? \"\" : \"<a href=\\\"//stackoverflow.com/users/\" + @mvp.Stackoverflow + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-stack-overflow px-1\\\"></i></a>\" )\r\n                        </div>\r\n                    </div>\r\n                </div>\r\n            </div>\r\n        }\r\n    </div>\r\n</div>"
+      }
+    ]
+  }
+}

--- a/Portals/0/2sxc/MVPs/_exports/View.LifetimeMVPs.json
+++ b/Portals/0/2sxc/MVPs/_exports/View.LifetimeMVPs.json
@@ -1,0 +1,87 @@
+{
+  "_": {
+    "V": 1
+  },
+  "Entity": {
+    "Id": 1751,
+    "Version": 1,
+    "Guid": "22f2482e-075f-40bb-8f4f-4dae2b27e505",
+    "Type": {
+      "Name": "2SexyContent-Template",
+      "Id": "2SexyContent-Template"
+    },
+    "Attributes": {
+      "String": {
+        "ContentTypeStaticName": {
+          "*": ""
+        },
+        "ListContentTypeStaticName": {
+          "*": ""
+        },
+        "ListPresentationTypeStaticName": {
+          "*": ""
+        },
+        "Location": {
+          "*": "Portal File System"
+        },
+        "Name": {
+          "*": "LifetimeMVPs"
+        },
+        "Path": {
+          "*": "_lifetimeMVPs.cshtml"
+        },
+        "PresentationTypeStaticName": {
+          "*": ""
+        },
+        "StreamsToPublish": {
+          "*": ""
+        },
+        "Type": {
+          "*": "C# Razor"
+        },
+        "ViewNameInUrl": {
+          "*": ""
+        }
+      },
+      "Entity": {
+        "ContentDemoEntity": {
+          "*": []
+        },
+        "ListContentDemoEntity": {
+          "*": []
+        },
+        "ListPresentationDemoEntity": {
+          "*": []
+        },
+        "Pipeline": {
+          "*": [
+            "00322596-3e9c-458e-ae7b-f3d172e0101a"
+          ]
+        },
+        "PresentationDemoEntity": {
+          "*": []
+        }
+      },
+      "Boolean": {
+        "IsHidden": {
+          "*": false
+        },
+        "PublishData": {
+          "*": false
+        },
+        "UseForList": {
+          "*": false
+        }
+      }
+    },
+    "Owner": "dnn:userid=2",
+    "Assets": [
+      {
+        "Storage": "app",
+        "Name": "_lifetimeMVPs.cshtml",
+        "Folder": "",
+        "File": "\r\n@Edit.Toolbar()\r\n<div class=\"container\">\r\n    <div class=\"row\">\r\n        @foreach(var mvp in AsDynamic(Data[\"LifetimeMVPs\"])){\r\n            <div class=\"card border-0 col-md-3 mb-3\">\r\n                <div class=\"bg-light rounded-top\">\r\n                    <img class=\"card-img-top rounded-circle p-4\" src=\"/DnnImageHandler.ashx?mode=profilepic&userId=@mvp.UserID&h=200&w=200\" alt=\"Card image cap\">\r\n                </div>\r\n                <div class=\"card-body text-center bg-secondary rounded-bottom\">\r\n                    <h4 class=\"card-title h-20\">@mvp.FirstName @mvp.LastName</h4>\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Country.ToString()) ? \"<p class=\\\"card-text h-20\\\">&nbsp;</p>\" : \"<p class=\\\"card-text\\\">\" + @mvp.Country + \"</p>\" )\r\n                    @Html.Raw(String.IsNullOrEmpty(@mvp.Website.ToString()) ? \"<p class=\\\"card-text h-20\\\"></p>\" : \"<p class=\\\"card-text\\\"><a href=\\\"\" + @mvp.Website + \"\\\" class=\\\"btn btn-primary\\\" target=\\\"_default\\\">Website</a></p>\" )\r\n                    <div class=\"row h-20\">\r\n                        <div class=\"col-md-12 h3\">\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Twitter.ToString()) ? \"\" : \"<a href=\\\"//twitter.com/\" + @mvp.Twitter + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-twitter px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.LinkedIn.ToString()) ? \"\" : \"<a href=\\\"//www.linkedin.com/in/\" + @mvp.LinkedIn + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-linkedin px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Facebook.ToString()) ? \"\" : \"<a href=\\\"//www.facebook.com/\" + @mvp.Facebook + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-facebook px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.GitHub.ToString()) ? \"\" : \"<a href=\\\"//github.com/\" + @mvp.GitHub + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-github px-1\\\"></i></a>\" )\r\n                            @Html.Raw(String.IsNullOrEmpty(@mvp.Stackoverflow.ToString()) ? \"\" : \"<a href=\\\"//stackoverflow.com/users/\" + @mvp.Stackoverflow + \"\\\" target=\\\"_default\\\"><i class=\\\"fa fa-stack-overflow px-1\\\"></i></a>\" )\r\n                        </div>\r\n                    </div>\r\n                </div>\r\n            </div>\r\n        }\r\n    </div>\r\n</div>"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
2sxc v13+ broke Dnn Agencies app. This was a very old version of the 2sxc News App and fell victim to multiple breaking changes (2sxc v10-v13). Created a new Details-redux View using only modern stuff (e.g. inheriting from Hybrid Razor12, Razor Blade, DI w Services, etc) and reading directly from the App.Data (instead of module content).
 
Also made minor changes to the List page to enable the new Details-redux output (/detail/ >> /agency-details/).

Catch-up (from 2021):
- added and hooked up a Demo page for my Dnn-Elements related blog post
- unfinished work on the semi-borked Leadership page 